### PR TITLE
Fix bin path due to ZIP hierarchy change

### DIFF
--- a/bucket/emacs-x.json
+++ b/bucket/emacs-x.json
@@ -10,14 +10,14 @@
         }
     },
     "bin": [
-        "bin\\runemacs.exe",
-        "bin\\emacs.exe",
-        "bin\\emacsclient.exe",
-        "bin\\emacsclientw.exe",
-        "bin\\etags.exe",
-        "bin\\ctags.exe",
+        "emacs-$version\\bin\\runemacs.exe",
+        "emacs-$version\\bin\\emacs.exe",
+        "emacs-$version\\bin\\emacsclient.exe",
+        "emacs-$version\\bin\\emacsclientw.exe",
+        "emacs-$version\\bin\\etags.exe",
+        "emacs-$version\\bin\\ctags.exe",
         [
-            "bin\\emacsclientw.exe",
+            "emacs-$version\\bin\\emacsclientw.exe",
             "emw",
             "-c -n -a \"\""
         ]
@@ -37,11 +37,11 @@
     },
     "shortcuts": [
         [
-            "bin\\runemacs.exe",
+            "emacs-$version\\bin\\runemacs.exe",
             "Emacs"
         ],
         [
-            "bin\\emacsclientw.exe",
+            "emacs-$version\\bin\\emacsclientw.exe",
             "Emacs Client",
             "-c -n -a \"\""
         ]


### PR DESCRIPTION
The bin folder is nested in emacs-28.2 folder. Running `scoop install emacs-x` currently results in _shim error (file not found)_. Simple fix to the paths of binaries should do the trick.

P.S. I have no way of testing whether `"$version"` in `"emacs-$version\\"` would be replaced by the current version's value. I simply assumed that it would be replaced by referring to the url in line 34. If it doesn't get replaced, I will fix the pull request with hardcoded value of `"28.2"`.